### PR TITLE
Create .env

### DIFF
--- a/experimentation/.env
+++ b/experimentation/.env
@@ -1,0 +1,2 @@
+MODEL_NAME='onnx emotion model'
+MLFLOW_TRACKING_URI="http://localhost:8999"


### PR DESCRIPTION
This env file is required because the port used internally for MLFlow is different to the port used externally.