### PR TITLE
Inference always uses production model

### DIFF
--- a/ml-frontend/logic/model_inference.py
+++ b/ml-frontend/logic/model_inference.py
@@ -16,7 +16,7 @@ class FacialEmotionInference:
 
     def __init__(self):
         # Simulate blue-green test; proper implementation would have validation for blue-green test
-        self.stage = 'production' if random() < .9 else 'staging'
+        self.stage = 'production'
 
     def predict(self, image: np.ndarray, model_id: str = ''):
         # Reshape input, and preprocess pixel to value between 0 and 1


### PR DESCRIPTION
Previously, inference in the front end is set to a 1 in 10 chance to use the staging model instead of the production model. This makes for some confusing situations when debugging. This pull requests make it so that the production model is always used.